### PR TITLE
Add api-test script and test that curve name passed in is valid.

### DIFF
--- a/lib/elliptic/ec/index.js
+++ b/lib/elliptic/ec/index.js
@@ -11,8 +11,13 @@ function EC(options) {
     return new EC(options);
 
   // Shortcut `elliptic.ec(curve-name)`
-  if (typeof options === 'string')
+  if (typeof options === 'string') {
+    if (!elliptic.curves.hasOwnProperty(options)) {
+      throw new Error('unknown curve ' + options);
+    }
+
     options = elliptic.curves[options];
+  }
 
   // Shortcut for `elliptic.ec(elliptic.curves.curveName)`
   if (options instanceof elliptic.curves.PresetCurve)

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -1,0 +1,17 @@
+var assert = require('assert');
+var elliptic = require('../');
+
+describe('EC API', function() {
+  it('should instantiate with valid curve (secp256k1)', function() {
+    var ec = new elliptic.ec('secp256k1');
+
+    assert(ec);
+    assert(typeof(ec) == "object");
+  });
+
+  it('should throw error with invalid curve', function() {
+    assert.throws(function(){
+      var ec = new elliptic.ec('nonexistent-curve');
+    }, Error);
+  });
+});


### PR DESCRIPTION
Hey,

I added an api-test.js script and a test to make sure the curve name passed in was valid. I had passed the curve name with a capital letter initially and having no error thrown meant I needed to spend extra time debugging what was happening so I figured I'd toss out a pull request to maybe save someone else the same time...

After running make, the dist file had quite a few extra diffs I wasn't expecting. All I intended to add were the changes to `lib/elliptic/ec/index.js` and `test/api-test.js`.
