### PR TITLE
Add benchs

### DIFF
--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -7,6 +7,7 @@ var eccjs = require('eccjs');
 var jodid = require('./deps/jodid');
 var ecdsa = require('ecdsa');
 var ECKey = require('eckey');
+var secp256k1 = require('secp256k1');
 
 var benchmarks = [];
 var maxTime = 10;
@@ -73,6 +74,12 @@ var k3 = new ECKey(crypto.randomBytes(32));
 var s3 = ecdsa.sign(m3, k3.privateKey);
 assert(ecdsa.verify(m3, s3, k3.publicKey));
 
+var m4 = crypto.createHash('sha256').update(str).digest();
+var k4priv = crypto.randomBytes(32);
+var k4pub = secp256k1.createPublicKey(k4priv);
+var s4 = secp256k1.sign(k4priv, m4);
+assert(secp256k1.verify(k4pub, m4, s4) > 0);
+
 add('sign', {
   elliptic: function() {
     c1.sign(m1, k1);
@@ -85,6 +92,9 @@ add('sign', {
   },
   ecdsa: function() {
     ecdsa.sign(m3, k3.privateKey);
+  },
+  secp256k1: function() {
+    secp256k1.sign(k4priv, m4);
   },
 });
 
@@ -105,6 +115,9 @@ add('verify', {
   },
   ecdsa: function() {
     ecdsa.verify(m3, s3, k3.publicKey);
+  },
+  secp256k1: function() {
+    secp256k1.verify(k4pub, m4, s4);
   },
 });
 

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -15,6 +15,7 @@
     "eckey": "^0.8.0",
     "hash.js": "^0.3.2",
     "jodid25519": "git://github.com/meganz/jodid25519.git",
+    "secp256k1": "~0.0.13",
     "sjcl": "^1.0.1"
   }
 }


### PR DESCRIPTION
Hi. I added [ecdsa](https://github.com/cryptocoinjs/ecdsa) and [secp256k1](https://github.com/wanderer/secp256k1-node) to the benchmark.

Results on my system:

```
Benchmarking: sign
elliptic#sign x 292 ops/sec ±0.73% (177 runs sampled)
sjcl#sign x 74.50 ops/sec ±0.40% (153 runs sampled)
openssl#sign x 2,145 ops/sec ±0.22% (198 runs sampled)
ecdsa#sign x 45.28 ops/sec ±0.15% (117 runs sampled)
secp256k1#sign x 9,598 ops/sec ±1.65% (191 runs sampled)
------------------------
Fastest is secp256k1#sign
========================
Benchmarking: verify
elliptic#verify x 133 ops/sec ±0.69% (170 runs sampled)
sjcl#verify x 63.09 ops/sec ±0.37% (130 runs sampled)
openssl#verify x 1,955 ops/sec ±0.06% (199 runs sampled)
ecdsa#verify x 32.84 ops/sec ±0.42% (114 runs sampled)
secp256k1#verify x 10,370 ops/sec ±0.03% (202 runs sampled)
------------------------
Fastest is secp256k1#verify
========================
Benchmarking: gen
elliptic#gen x 321 ops/sec ±0.45% (182 runs sampled)
sjcl#gen x 82.28 ops/sec ±0.07% (141 runs sampled)
------------------------
Fastest is elliptic#gen
========================
Benchmarking: ecdh
elliptic#ecdh x 165 ops/sec ±0.80% (169 runs sampled)
------------------------
Fastest is elliptic#ecdh
========================
Benchmarking: curve25519
elliptic#curve25519 x 75.02 ops/sec ±2.64% (115 runs sampled)
jodid#curve25519 x 107 ops/sec ±0.30% (156 runs sampled)
------------------------
Fastest is jodid#curve25519
========================
```
