### PR TITLE
Bump `hash.js` to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "bn.js": "^0.16.0",
     "brorand": "^1.0.1",
-    "hash.js": "^0.2.0",
+    "hash.js": "^0.3.2",
     "inherits": "^2.0.1"
   }
 }


### PR DESCRIPTION
This is generating npm issues when trying to use the latestest versions of `hash.js` and `elliptic` at the same time.