### PR TITLE
WIP: Problem with _endoWnafMulAdd

### DIFF
--- a/lib/elliptic/curve/short.js
+++ b/lib/elliptic/curve/short.js
@@ -424,8 +424,6 @@ Point.prototype.mul = function mul(k) {
 
   if (this.precomputed && this.precomputed.doubles)
     return this.curve._fixedNafMul(this, k);
-  else if (this.curve.endo)
-    return this.curve._endoWnafMulAdd([ this ], [ k ]);
   else
     return this.curve._wnafMul(this, k);
 };

--- a/test/curve-test.js
+++ b/test/curve-test.js
@@ -74,6 +74,18 @@ describe('Curve', function() {
       k.toString(16));
   });
 
+  it('should compute this problematic secp256k1 multiplication', function() {
+    var curve = elliptic.curves.secp256k1.curve;
+    var g1 = curve.g; // precomputed g
+    assert(g1.precomputed);
+    var g2 = curve.point(g1.getX(), g1.getY()); // not precomputed g
+    assert(!g2.precomputed);
+    var a = new bn('6d1229a6b24c2e775c062870ad26bc261051e0198c67203167273c7c62538846', 16);
+    var p1 = g1.mul(a);
+    var p2 = g2.mul(a);
+    assert(p1.eq(p2));
+  });
+
   it('should not fail on secp256k1 regression', function() {
     var curve = elliptic.curves.secp256k1.curve;
     var k1 = new bn('32efeba414cd0c830aed727749e816a01c471831536fd2fce28c56b54f5a3bb1', 16);


### PR DESCRIPTION
There is a problem with point multiplication on short curves. If the point being multiplied does not have precomputed values, it can sometimes lead to incorrect results. This issue was discovered by @braydonf in https://github.com/indutny/elliptic/issues/17 . This WIP PR is an attempt to show explicitly what the problem is by adding a test that fails, and to fix it by removing the call to _endoWnafMulAdd. The failing test simply multiplies G by the same problematic value discovered by @braydonf, both when G does have precomputed values, and when G does not have precomputed values. This shouldn't make a difference to the result, but it does. I also demonstrate a solution, but the solution is inadequate because it makes point multiplication much slower. I'm not sure what the actual error is, other than that it is located somewhere in _endoWnafMulAdd.