### PR TITLE
don't bring in the whole assert library

### DIFF
--- a/lib/elliptic/curve/base.js
+++ b/lib/elliptic/curve/base.js
@@ -1,7 +1,6 @@
 var bn = require('bn.js');
 var elliptic = require('../../elliptic');
 
-
 var getNAF = elliptic.utils.getNAF;
 var getJSF = elliptic.utils.getJSF;
 var assert = elliptic.utils.assert;

--- a/lib/elliptic/curve/base.js
+++ b/lib/elliptic/curve/base.js
@@ -1,9 +1,10 @@
-var assert = require('assert');
 var bn = require('bn.js');
 var elliptic = require('../../elliptic');
 
+
 var getNAF = elliptic.utils.getNAF;
 var getJSF = elliptic.utils.getJSF;
+var assert = elliptic.utils.assert;
 
 function BaseCurve(type, conf) {
   this.type = type;

--- a/lib/elliptic/curve/edwards.js
+++ b/lib/elliptic/curve/edwards.js
@@ -1,4 +1,3 @@
-var assert = require('assert');
 var curve = require('../curve');
 var elliptic = require('../../elliptic');
 var bn = require('bn.js');
@@ -6,6 +5,7 @@ var inherits = require('inherits');
 var Base = curve.base;
 
 var getNAF = elliptic.utils.getNAF;
+var assert = elliptic.utils.assert;
 
 function EdwardsCurve(conf) {
   // NOTE: Important as we are creating point in Base.call()

--- a/lib/elliptic/curve/mont.js
+++ b/lib/elliptic/curve/mont.js
@@ -1,4 +1,3 @@
-var assert = require('assert');
 var curve = require('../curve');
 var elliptic = require('../../elliptic');
 var bn = require('bn.js');
@@ -6,6 +5,7 @@ var inherits = require('inherits');
 var Base = curve.base;
 
 var getNAF = elliptic.utils.getNAF;
+var assert = elliptic.utils.assert;
 
 function MontCurve(conf) {
   Base.call(this, 'mont', conf);

--- a/lib/elliptic/curve/short.js
+++ b/lib/elliptic/curve/short.js
@@ -1,4 +1,3 @@
-var assert = require('assert');
 var curve = require('../curve');
 var elliptic = require('../../elliptic');
 var bn = require('bn.js');
@@ -6,6 +5,7 @@ var inherits = require('inherits');
 var Base = curve.base;
 
 var getNAF = elliptic.utils.getNAF;
+var assert = elliptic.utils.assert;
 
 function ShortCurve(conf) {
   Base.call(this, 'short', conf);

--- a/lib/elliptic/curves.js
+++ b/lib/elliptic/curves.js
@@ -1,9 +1,10 @@
 var curves = exports;
 
-var assert = require('assert');
 var hash = require('hash.js');
 var bn = require('bn.js');
 var elliptic = require('../elliptic');
+
+var assert = elliptic.utils.assert;
 
 function PresetCurve(options) {
   if (options.type === 'short')

--- a/lib/elliptic/ec/index.js
+++ b/lib/elliptic/ec/index.js
@@ -1,7 +1,7 @@
-var assert = require('assert');
 var bn = require('bn.js');
 var elliptic = require('../../elliptic');
 var utils = elliptic.utils;
+var assert = utils.assert;
 
 var KeyPair = require('./key');
 var Signature = require('./signature');

--- a/lib/elliptic/ec/key.js
+++ b/lib/elliptic/ec/key.js
@@ -1,8 +1,8 @@
-var assert = require('assert');
 var bn = require('bn.js');
 
 var elliptic = require('../../elliptic');
 var utils = elliptic.utils;
+var assert = utils.assert;
 
 function KeyPair(ec, priv, pub) {
   if (priv instanceof KeyPair)

--- a/lib/elliptic/ec/signature.js
+++ b/lib/elliptic/ec/signature.js
@@ -1,8 +1,8 @@
-var assert = require('assert');
 var bn = require('bn.js');
 
 var elliptic = require('../../elliptic');
 var utils = elliptic.utils;
+var assert = utils.assert;
 
 function Signature(r, s) {
   if (r instanceof Signature)

--- a/lib/elliptic/hmac-drbg.js
+++ b/lib/elliptic/hmac-drbg.js
@@ -1,8 +1,8 @@
-var assert = require('assert');
 
 var hash = require('hash.js');
 var elliptic = require('../elliptic');
 var utils = elliptic.utils;
+var assert = utils.assert;
 
 function HmacDRBG(options) {
   if (!(this instanceof HmacDRBG))

--- a/lib/elliptic/hmac-drbg.js
+++ b/lib/elliptic/hmac-drbg.js
@@ -1,4 +1,3 @@
-
 var hash = require('hash.js');
 var elliptic = require('../elliptic');
 var utils = elliptic.utils;

--- a/lib/elliptic/utils.js
+++ b/lib/elliptic/utils.js
@@ -1,10 +1,12 @@
 var bn = require('bn.js');
 
 var utils = exports;
+
 utils.assert = function assert(val, msg) {
   if (!val)
     throw new Error(msg || 'Assertion failed');
 };
+
 function toArray(msg, enc) {
   if (Array.isArray(msg))
     return msg.slice();

--- a/lib/elliptic/utils.js
+++ b/lib/elliptic/utils.js
@@ -1,8 +1,10 @@
-var assert = require('assert');
 var bn = require('bn.js');
 
 var utils = exports;
-
+utils.assert = function assert(val, msg) {
+  if (!val)
+    throw new Error(msg || 'Assertion failed');
+};
 function toArray(msg, enc) {
   if (Array.isArray(msg))
     return msg.slice();


### PR DESCRIPTION
I grabbed the assert function you used in bn.js, considering you only use assert() assert by itself is pretty big PLUS it brings in utils