### PR TITLE
Swap out brorand and hash.js

### DIFF
--- a/lib/elliptic.js
+++ b/lib/elliptic.js
@@ -2,7 +2,7 @@ var elliptic = exports;
 
 elliptic.version = require('../package.json').version;
 elliptic.utils = require('./elliptic/utils');
-elliptic.rand = require('brorand');
+elliptic.rand = require('randombytes');
 elliptic.hmacDRBG = require('./elliptic/hmac-drbg');
 elliptic.curve = require('./elliptic/curve');
 elliptic.curves = require('./elliptic/curves');

--- a/lib/elliptic/curves.js
+++ b/lib/elliptic/curves.js
@@ -1,6 +1,6 @@
 var curves = exports;
 
-var hash = require('hash.js');
+var hash = require('./hash');
 var bn = require('bn.js');
 var elliptic = require('../elliptic');
 

--- a/lib/elliptic/hash.js
+++ b/lib/elliptic/hash.js
@@ -1,0 +1,48 @@
+var createHash = require('create-hash');
+var createHmac = require('create-hmac');
+
+function makeHash(algo) {
+  function out() {
+    return createHash(algo);
+  }
+  if (algo === 'sha1') {
+    out.hmacStrength = 80;
+    out.outSize = 160;
+  } else {
+    out.hmacStrength = 192;
+    out.outSize = parseInt(algo.toLowerCase().match(/sha(\d\d\d)/)[1], 10);
+  }
+  out.hashName = algo;
+  return out;
+}
+
+exports.hmac = function (hash, key) {
+  return new Hmac(hash.hashName, key);
+};
+
+function Hmac(algo, key) {
+  if (Array.isArray(key)) {
+    key = new Buffer(key);
+  }
+  this.hmac  = createHmac(algo, key);
+}
+
+Hmac.prototype.digest = function () {
+  return this.hmac.digest();
+};
+
+Hmac.prototype.update = function (array) {
+  if (!array) {
+    return this;
+  }
+  if (Array.isArray(array)) {
+    array = new Buffer(array);
+  }
+  this.hmac.update(new Buffer(array));
+  return this;
+};
+exports.sha1 = makeHash('sha1');
+exports.sha224 = makeHash('sha224');
+exports.sha256 = makeHash('sha256');
+exports.sha384 = makeHash('sha384');
+exports.sha512 = makeHash('sha512');

--- a/lib/elliptic/hmac-drbg.js
+++ b/lib/elliptic/hmac-drbg.js
@@ -1,4 +1,4 @@
-var hash = require('hash.js');
+var hash = require('./hash');
 var elliptic = require('../elliptic');
 var utils = elliptic.utils;
 var assert = utils.assert;
@@ -27,10 +27,10 @@ function HmacDRBG(options) {
 module.exports = HmacDRBG;
 
 HmacDRBG.prototype._init = function init(entropy, nonce, pers) {
-  var seed = entropy.concat(nonce).concat(pers);
+  var seed = new Buffer(entropy.concat(nonce).concat(pers));
 
-  this.K = new Array(this.outLen / 8);
-  this.V = new Array(this.outLen / 8);
+  this.K = new Buffer(this.outLen / 8);
+  this.V = new Buffer(this.outLen / 8);
   for (var i = 0; i < this.V.length; i++) {
     this.K[i] = 0x00;
     this.V[i] = 0x01;
@@ -48,17 +48,16 @@ HmacDRBG.prototype._hmac = function hmac() {
 HmacDRBG.prototype._update = function update(seed) {
   var kmac = this._hmac()
                  .update(this.V)
-                 .update([ 0x00 ]);
+                 .update(new Buffer([0x00]));
   if (seed)
     kmac = kmac.update(seed);
   this.K = kmac.digest();
   this.V = this._hmac().update(this.V).digest();
   if (!seed)
     return;
-
   this.K = this._hmac()
                .update(this.V)
-               .update([ 0x01 ])
+               .update(new Buffer([0x01]))
                .update(seed)
                .digest();
   this.V = this._hmac().update(this.V).digest();
@@ -72,8 +71,8 @@ HmacDRBG.prototype.reseed = function reseed(entropy, entropyEnc, add, addEnc) {
     entropyEnc = null;
   }
 
-  entropy = utils.toBuffer(entropy, entropyEnc);
-  add = utils.toBuffer(add, addEnc);
+  entropy = utils.toArray(entropy, entropyEnc);
+  add = utils.toArray(add, addEnc);
 
   assert(entropy.length >= (this.minEntropy / 8),
          'Not enough entropy. Minimum is: ' + this.minEntropy + ' bits');
@@ -99,14 +98,16 @@ HmacDRBG.prototype.generate = function generate(len, enc, add, addEnc) {
     this._update(add);
   }
 
-  var temp = [];
+  var temp = new Buffer('');
   while (temp.length < len) {
     this.V = this._hmac().update(this.V).digest();
-    temp = temp.concat(this.V);
+    temp = Buffer.concat([temp, this.V]);
   }
-
   var res = temp.slice(0, len);
   this._update(add);
   this.reseed++;
-  return utils.encode(res, enc);
+  if (enc) 
+    return res.toString(enc);
+  else
+    return res;
 };

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "dependencies": {
     "bn.js": "^1.0.0",
-    "hash.js": "^1.0.0",
+    "create-hash": "^1.1.0",
+    "create-hmac": "^1.1.0",
     "inherits": "^2.0.1",
     "randombytes": "^2.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "dependencies": {
     "bn.js": "^1.0.0",
-    "brorand": "^1.0.1",
     "hash.js": "^1.0.0",
-    "inherits": "^2.0.1"
+    "inherits": "^2.0.1",
+    "randombytes": "^2.0.0"
   }
 }

--- a/test/ecdh-test.js
+++ b/test/ecdh-test.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 var elliptic = require('../');
-var hash = require('hash.js');
+var hash = require('../lib/elliptic/hash');
 
 describe('ECDH', function() {
   function test(name) {

--- a/test/ecdsa-test.js
+++ b/test/ecdsa-test.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 var elliptic = require('../');
-var hash = require('hash.js');
+var hash = require('../lib/elliptic/hash');
 
 describe('ECDSA', function() {
   function test(name) {
@@ -71,7 +71,7 @@ describe('ECDSA', function() {
           hash: c.hash
         });
         var descr = 'should not fail on "' + opt.name + '" ' +
-                    'and hash ' + c.hash.name + ' on "' + c.message + '"';
+                    'and hash ' + c.hash.hashName + ' on "' + c.message + '"';
         it(descr, function() {
           var dgst = c.hash().update(c.message).digest();
           var sign = ecdsa.sign(dgst, opt.key);

--- a/test/hmac-drbg-test.js
+++ b/test/hmac-drbg-test.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var elliptic = require('../');
 var utils = elliptic.utils;
-var hash = require('hash.js');
+var hash = require('../lib/elliptic/hash');
 
 describe('Hmac_DRBG', function() {
   it('should support hmac-drbg-sha256', function() {


### PR DESCRIPTION
this swaps out brorand and hash.js for randombytes, create-hash, and create-hmac, all 3 of the libraries are the modularized crypto browserify shims which just use the crypto module in node and only use the pure js shim in the browser.