### PR TITLE
Fixed PK encoding unused during import

### DIFF
--- a/lib/elliptic/ec/key.js
+++ b/lib/elliptic/ec/key.js
@@ -93,7 +93,7 @@ KeyPair.prototype.getPrivate = function getPrivate(enc) {
 };
 
 KeyPair.prototype._importPrivate = function _importPrivate(key, enc) {
-  this.priv = new bn(key, 16);
+  this.priv = new bn(key, enc || 16);
 
   // Ensure that the priv won't be bigger than n, otherwise we may fail
   // in fixed multiplication method


### PR DESCRIPTION
Typo?