### PR TITLE
[WIP] Move point codec code from ec/key to curve/base

### DIFF
--- a/lib/elliptic/curve/base.js
+++ b/lib/elliptic/curve/base.js
@@ -2,10 +2,11 @@
 
 var bn = require('bn.js');
 var elliptic = require('../../elliptic');
-
-var getNAF = elliptic.utils.getNAF;
-var getJSF = elliptic.utils.getJSF;
-var assert = elliptic.utils.assert;
+var utils = elliptic.utils;
+var getNAF = utils.getNAF;
+var getJSF = utils.getJSF;
+var assert = utils.assert;
+var intToBE = utils.intToBE;
 
 function BaseCurve(type, conf) {
   this.type = type;
@@ -239,8 +240,49 @@ function BasePoint(curve, type) {
 }
 BaseCurve.BasePoint = BasePoint;
 
+BasePoint.prototype.eq = function eq(/*other*/) {
+  throw new Error('Not implemented');
+};
+
 BasePoint.prototype.validate = function validate() {
   return this.curve.validate(this);
+};
+
+BaseCurve.prototype.decodePoint = function decodePoint(bytes, enc) {
+  bytes = utils.toArray(bytes, enc);
+
+  var len = this.p.byteLength();
+  if (bytes[0] === 0x04 && bytes.length - 1 === 2 * len) {
+    return this.point(bytes.slice(1, 1 + len),
+                      bytes.slice(1 + len, 1 + 2 * len));
+  } else if ((bytes[0] === 0x02 || bytes[0] === 0x03) &&
+              bytes.length - 1 === len) {
+    return this.pointFromX(bytes.slice(1, 1 + len), bytes[0] === 0x03);
+  }
+  throw new Error('Unknown point format');
+};
+
+BasePoint.prototype.encodeCompressed = function encodeCompressed(enc) {
+  return this.encode(true, enc);
+};
+
+BasePoint.prototype._encode = function _encode(compact) {
+  var len = this.curve.p.byteLength();
+  var x = intToBE(this.getX(), len);
+
+  return compact ?
+      [ this.getY().isEven() ? 0x02 : 0x03 ].concat(x) :
+      [ 0x04 ].concat(x, intToBE(this.getY(), len)) ;
+};
+
+BasePoint.prototype.encode = function encode(compact, enc) {
+  // compact is optional argument
+  if (typeof compact === 'string') {
+    enc = compact;
+    compact = null;
+  }
+
+  return utils.encode(this._encode(compact), enc);
 };
 
 BasePoint.prototype.precompute = function precompute(power) {

--- a/lib/elliptic/curve/mont.js
+++ b/lib/elliptic/curve/mont.js
@@ -5,6 +5,9 @@ var bn = require('bn.js');
 var inherits = require('inherits');
 var Base = curve.base;
 
+var elliptic = require('../../elliptic');
+var utils = elliptic.utils;
+
 function MontCurve(conf) {
   Base.call(this, 'mont', conf);
 
@@ -42,6 +45,10 @@ function Point(curve, x, z) {
 }
 inherits(Point, Base.BasePoint);
 
+MontCurve.prototype.decodePoint = function decodePoint(bytes, enc) {
+  return this.point(utils.toArray(bytes, enc), 1);
+};
+
 MontCurve.prototype.point = function point(x, z) {
   return new Point(this, x, z);
 };
@@ -52,6 +59,10 @@ MontCurve.prototype.pointFromJSON = function pointFromJSON(obj) {
 
 Point.prototype.precompute = function precompute() {
   // No-op
+};
+
+Point.prototype._encode = function _encode(/*compact ignored*/) {
+  return utils.intToBE(this.getX(), this.curve.p.byteLength());
 };
 
 Point.fromJSON = function fromJSON(curve, obj) {
@@ -145,6 +156,10 @@ Point.prototype.mul = function mul(k) {
 
 Point.prototype.mulAdd = function mulAdd() {
   throw new Error('Not supported on Montgomery curve');
+};
+
+Point.prototype.eq = function eq(other) {
+  return this.getX().cmp(other.getX()) === 0;
 };
 
 Point.prototype.normalize = function normalize() {

--- a/lib/elliptic/ec/key.js
+++ b/lib/elliptic/ec/key.js
@@ -2,9 +2,6 @@
 
 var bn = require('bn.js');
 
-var elliptic = require('../../elliptic');
-var utils = elliptic.utils;
-
 function KeyPair(ec, options) {
   this.ec = ec;
   this.priv = null;
@@ -52,39 +49,19 @@ KeyPair.prototype.validate = function validate() {
 };
 
 KeyPair.prototype.getPublic = function getPublic(compact, enc) {
-  if (!this.pub)
-    this.pub = this.ec.g.mul(this.priv);
-
   // compact is optional argument
   if (typeof compact === 'string') {
     enc = compact;
     compact = null;
   }
 
+  if (!this.pub)
+    this.pub = this.ec.g.mul(this.priv);
+
   if (!enc)
     return this.pub;
 
-  var len = this.ec.curve.p.byteLength();
-  var x = this.pub.getX().toArray();
-
-  for (var i = x.length; i < len; i++)
-    x.unshift(0);
-
-  var res;
-  if (this.ec.curve.type !== 'mont') {
-    if (compact) {
-      res = [ this.pub.getY().isEven() ? 0x02 : 0x03 ].concat(x);
-    } else {
-      var y = this.pub.getY().toArray();
-      for (var i = y.length; i < len; i++)
-        y.unshift(0);
-      var res = [ 0x04 ].concat(x, y);
-    }
-  } else {
-    res = x;
-  }
-
-  return utils.encode(res, enc);
+  return this.pub.encode(compact, enc);
 };
 
 KeyPair.prototype.getPrivate = function getPrivate(enc) {
@@ -107,27 +84,7 @@ KeyPair.prototype._importPublic = function _importPublic(key, enc) {
     this.pub = this.ec.curve.point(key.x, key.y);
     return;
   }
-
-  key = utils.toArray(key, enc);
-  if (this.ec.curve.type !== 'mont')
-    return this._importPublicShort(key);
-  else
-    return this._importPublicMont(key);
-};
-
-KeyPair.prototype._importPublicShort = function _importPublicShort(key) {
-  var len = this.ec.curve.p.byteLength();
-  if (key[0] === 0x04 && key.length - 1 === 2 * len) {
-    this.pub = this.ec.curve.point(
-      key.slice(1, 1 + len),
-      key.slice(1 + len, 1 + 2 * len));
-  } else if ((key[0] === 0x02 || key[0] === 0x03) && key.length - 1 === len) {
-    this.pub = this.ec.curve.pointFromX(key.slice(1, 1 + len), key[0] === 0x03);
-  }
-};
-
-KeyPair.prototype._importPublicMont = function _importPublicMont(key) {
-  this.pub = this.ec.curve.point(key, 1);
+  this.pub = this.ec.curve.decodePoint(key, enc);
 };
 
 // ECDH

--- a/lib/elliptic/utils.js
+++ b/lib/elliptic/utils.js
@@ -177,3 +177,11 @@ function intToLE(num, padTo) {
   return bytes;
 }
 utils.intToLE = intToLE;
+
+function intToBE(num, padTo) {
+  var bytes = num.toArray();
+  while (bytes.length < padTo)
+    bytes.unshift(0);
+  return bytes;
+}
+utils.intToBE = intToBE;


### PR DESCRIPTION
re #42 

This just takes the existing point codec code that was inside the KeyPair class and moves it the BaseCurve / BasePoint classes. It didn't really seem advantageous to go to unnatural lengths to have default implementation and various over-rides. Thoughts?