### PR TITLE
better der encoding

### DIFF
--- a/lib/elliptic/ec/signature.js
+++ b/lib/elliptic/ec/signature.js
@@ -23,34 +23,87 @@ function Signature(options, enc) {
 }
 module.exports = Signature;
 
+function Position() {
+  this.place = 0;
+}
+
+function getLength(buf, p) {
+  var initial = buf[p.place++];
+  if (!(initial & 0x80)) {
+    return initial;
+  }
+  var octetLen = initial & 0xf;
+  var val = 0;
+  for (var i = 0, off = p.place; i < octetLen; i++, off++) {
+    val <<= 8;
+    val |= buf[off];
+  }
+  p.place = off;
+  return val;
+}
+
+function rmPadding(buf) {
+  var i = 0;
+  var len = buf.length - 1;
+  while (!buf[i] && !(buf[i + 1] & 0x80) && i < len) {
+    i++;
+  }
+  if (i === 0) {
+    return buf;
+  }
+  return buf.slice(i);
+}
+
 Signature.prototype._importDER = function _importDER(data, enc) {
   data = utils.toArray(data, enc);
-  if (data.length < 6 || data[0] !== 0x30 || data[2] !== 0x02)
+  var p = new Position();
+  if (data[p.place++] !== 0x30) {
     return false;
-  var total = data[1];
-  if (1 + total > data.length)
+  }
+  var len = getLength(data, p);
+  if ((len + p.place) !== data.length) {
     return false;
-  var rlen = data[3];
-  // Short length notation
-  if (rlen >= 0x80)
+  }
+  if (data[p.place++] !== 0x02) {
     return false;
-  if (4 + rlen + 2 >= data.length)
+  }
+  var rlen = getLength(data, p);
+  var r = data.slice(p.place, rlen + p.place);
+  p.place += rlen;
+  if (data[p.place++] !== 0x02) {
     return false;
-  if (data[4 + rlen] !== 0x02)
+  }
+  var slen = getLength(data, p);
+  if (data.length !== slen + p.place) {
     return false;
-  var slen = data[5 + rlen];
-  // Short length notation
-  if (slen >= 0x80)
-    return false;
-  if (4 + rlen + 2 + slen > data.length)
-    return false;
+  }
+  var s = data.slice(p.place, slen + p.place);
+  if (r[0] === 0 && (r[1] & 0x80)) {
+    r = r.slice(1);
+  }
+  if (s[0] === 0 && (s[1] & 0x80)) {
+    s = s.slice(1);
+  }
 
-  this.r = new bn(data.slice(4, 4 + rlen));
-  this.s = new bn(data.slice(4 + rlen + 2, 4 + rlen + 2 + slen));
+  this.r = new bn(r);
+  this.s = new bn(s);
   this.recoveryParam = null;
 
   return true;
 };
+
+function constructLength(arr, len) {
+  if (len < 0x80) {
+    arr.push(len);
+    return;
+  }
+  var octets = 1 + (Math.log(len) / Math.LN2 >>> 3);
+  arr.push(octets | 0x80);
+  while (--octets) {
+    arr.push((len >>> (octets << 3)) & 0xff);
+  }
+  arr.push(len);
+}
 
 Signature.prototype.toDER = function toDER(enc) {
   var r = this.r.toArray();
@@ -63,8 +116,20 @@ Signature.prototype.toDER = function toDER(enc) {
   if (s[0] & 0x80)
     s = [ 0 ].concat(s);
 
-  var total = r.length + s.length + 4;
-  var res = [ 0x30, total, 0x02, r.length ];
-  res = res.concat(r, [ 0x02, s.length ], s);
+  r = rmPadding(r);
+  s = rmPadding(s);
+
+  while (!s[0] && !(s[1] & 0x80)) {
+    s = s.slice(1);
+  }
+  var arr = [ 0x02 ];
+  constructLength(arr, r.length);
+  arr = arr.concat(r);
+  arr.push(0x02);
+  constructLength(arr, s.length);
+  var backHalf = arr.concat(s);
+  var res = [ 0x30 ];
+  constructLength(res, backHalf.length);
+  res = res.concat(backHalf);
   return utils.encode(res, enc);
 };

--- a/test/ecdsa-test.js
+++ b/test/ecdsa-test.js
@@ -5,6 +5,7 @@ var hash = require('hash.js');
 describe('ECDSA', function() {
   function test(name) {
     it('should work with ' + name + ' curve', function() {
+      this.timeout(5000);
       var curve = elliptic.curves[name];
       assert(curve);
 
@@ -16,11 +17,16 @@ describe('ECDSA', function() {
         ]
       });
       var msg = 'deadbeef';
-
+      var keylen = 64;
+      if (name === 'p384') {
+        keylen = 96;
+      } else if (name === 'p521') {
+        keylen = 132
+      }
       // Get keys out of pair
       assert(keys.getPublic().x && keys.getPublic().y);
       assert(keys.getPrivate().length > 0);
-      assert.equal(keys.getPrivate('hex').length, 64);
+      assert.equal(keys.getPrivate('hex').length, keylen);
       assert(keys.getPublic('hex').length > 0);
       assert(keys.getPrivate('hex').length > 0);
       assert(keys.validate().result);
@@ -40,7 +46,7 @@ describe('ECDSA', function() {
 
       // key.sign(msg, options)
       var sign = keys.sign('hello', { canonical: true });
-      assert.notEqual(sign.toDER('hex'), keys.sign('hello').toDER('hex'));
+      assert(sign.s.cmp(keys.ec.nh) <= 0);
 
       // Load public key from compact hex
       var keys = ecdsa.keyFromPublic(keys.getPublic(true, 'hex'), 'hex');
@@ -66,6 +72,9 @@ describe('ECDSA', function() {
   }
   test('secp256k1');
   test('ed25519');
+  test('p256');
+  test('p384');
+  test('p521');
 
   describe('RFC6979 vector', function() {
     function test(opt) {


### PR DESCRIPTION
p521 keys can have a total length greater then 127 bits leading to it being in long form, this covers that through we might just want to use asn1 instead of this.  Also adds tests for it but since p384 and p521 don't actually have malability issues rewrote the test to be more direct about what is being tested.