### PR TITLE
Use package.json files field instead of npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-benchmarks/
-node_modules/
-dist/*.js
-npm-debug.log
-1.js
-v8.log

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "6.0.1",
   "description": "EC cryptography",
   "main": "lib/elliptic.js",
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "test": "make lint && istanbul test _mocha --reporter=spec test/*-test.js",
     "coveralls": "cat ./coverage/lcov.info | coveralls"


### PR DESCRIPTION
With tests gziped package is 920kb. Without them just 38kb.