### PR TITLE
Allow pass pers to drbg from ec.sign

### DIFF
--- a/lib/elliptic/ec/index.js
+++ b/lib/elliptic/ec/index.js
@@ -105,7 +105,9 @@ EC.prototype.sign = function sign(msg, key, enc, options) {
   var drbg = new elliptic.hmacDRBG({
     hash: this.hash,
     entropy: bkey,
-    nonce: nonce
+    nonce: nonce,
+    pers: options.pers,
+    persEnc: options.persEnc
   });
 
   // Number of bytes to generate

--- a/test/ecdsa-test.js
+++ b/test/ecdsa-test.js
@@ -74,6 +74,13 @@ describe('ECDSA', function() {
         assert(ecdsa.verify(msg, sign, keys), 'custom-k verify');
       });
 
+      it('should have another signature with pers', function () {
+        var sign1 = keys.sign(msg);
+        var sign2 = keys.sign(msg, {pers: '1234', persEnc: 'hex'});
+        assert.notEqual(sign1.r.toArray().concat(sign1.s.toArray()),
+                        sign2.r.toArray().concat(sign2.s.toArray()));
+      });
+
       it('should load public key from compact hex value', function() {
         var pub = keys.getPublic(true, 'hex');
         var copy = ecdsa.keyFromPublic(pub, 'hex');


### PR DESCRIPTION
In #68 I forgot mentioned that secp256k1-node v3.0.0 also need pass extra data to drbg.