### PR TITLE
lib: fix recoveryParam in ECDSA Signature

### DIFF
--- a/lib/elliptic/ec/signature.js
+++ b/lib/elliptic/ec/signature.js
@@ -16,10 +16,10 @@ function Signature(options, enc) {
   assert(options.r && options.s, 'Signature without r or s');
   this.r = new BN(options.r, 16);
   this.s = new BN(options.s, 16);
-  if (options.recoveryParam)
-    this.recoveryParam = options.recoveryParam;
-  else
+  if (options.recoveryParam === undefined)
     this.recoveryParam = null;
+  else
+    this.recoveryParam = options.recoveryParam;
 }
 module.exports = Signature;
 

--- a/test/ecdsa-test.js
+++ b/test/ecdsa-test.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
 var elliptic = require('../');
+var Signature = require('../lib/elliptic/ec/signature')
 var BN = require('bn.js');
 var hash = require('hash.js');
 
@@ -380,6 +381,18 @@ describe('ECDSA', function() {
         r: 'fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140',
         s: '8887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3',
       }, 0);
+    });
+  });
+
+  describe('Signature', function () {
+    it('recoveryParam is 0', function () {
+      var sig = new Signature({r: '00', s: '00', recoveryParam: 0});
+      assert.equal(sig.recoveryParam, 0);
+    });
+
+    it('recoveryParam is 1', function () {
+      var sig = new Signature({r: '00', s: '00', recoveryParam: 1});
+      assert.equal(sig.recoveryParam, 1);
     });
   });
 });


### PR DESCRIPTION
check only on `undefined`, because `Signature` is internal