### PR TITLE
X25519 test vectors from RFC7748

### DIFF
--- a/test/ecdh-test.js
+++ b/test/ecdh-test.js
@@ -25,3 +25,27 @@ describe('ECDH', function() {
   test('ed25519');
   test('secp256k1');
 });
+
+describe('X25519', function() {
+  // See https://tools.ietf.org/html/rfc7748#section-6.1
+  const ALICE_SECRET_KEY = '77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a';
+  const ALICE_PUBLIC_KEY = '8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a';
+  const BOB_SECRET_KEY = '5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb';
+  const BOB_PUBLIC_KEY = 'de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f';
+  const SHARED_SECRET = '4a5d9d5ba4ce2de1728e3bf480350f25e07e21c947d19e3376f09b3c1e161742';
+
+  const ec = new elliptic.ec('curve25519');
+
+  const aliceKeyPair = ec.keyFromPrivate(ALICE_SECRET_KEY, 'hex');
+  assert.equal(ALICE_SECRET_KEY, aliceKeyPair.getPrivate('hex'));
+  assert.equal(ALICE_PUBLIC_KEY, aliceKeyPair.getPublic('hex'));
+
+  const bobKeyPair = ec.keyFromPrivate(BOB_SECRET_KEY, 'hex');
+  assert.equal(BOB_SECRET_KEY, bobKeyPair.getPrivate('hex'));
+  assert.equal(BOB_PUBLIC_KEY, bobKeyPair.getPublic('hex'));
+
+  const aliceSharedSecret = aliceKeyPair.derive(ec.keyFromPrivate(BOB_PUBLIC_KEY, 'hex').getPublic());
+  assert.equal(SHARED_SECRET, aliceSharedSecret.toString(16));
+  const bobSharedSecret = bobKeyPair.derive(ec.keyFromPrivate(ALICE_PUBLIC_KEY, 'hex').getPublic());
+  assert.equal(SHARED_SECRET, bobSharedSecret.toString(16));
+});


### PR DESCRIPTION
I'm trying to use elliptic.js for X25519 ECDH to interop with libsodium, but I'm having problems doing so. I can't even get elliptic.js to verify against the X25519 test vectors from RFC7748. What am I doing wrong?