### PR TITLE
feat(curves): Add curve25519 in Weierstrass form

### DIFF
--- a/lib/elliptic/curves.js
+++ b/lib/elliptic/curves.js
@@ -146,6 +146,21 @@ defineCurve('curve25519', {
   ]
 });
 
+defineCurve('curve25519-weier', {
+  type: 'short',
+  prime: 'p25519',
+  p: '7fffffffffffffff ffffffffffffffff ffffffffffffffff ffffffffffffffed',
+  a: '2aaaaaaaaaaaaaaa aaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaa aaaaaa984914a144',
+  b: '7b425ed097b425ed 097b425ed097b425 ed097b425ed097b4 260b5e9c7710c864',
+  n: '1000000000000000 0000000000000000 14def9dea2f79cd6 5812631a5cf5d3ed',
+  hash: hash.sha256,
+  gRed: false,
+  g: [
+    '2aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaad245a',
+    '20ae19a1b8a086b4e01edd2c7748d14c923d4d7e6d7c61b229e9c5a27eced3d9'
+  ]
+});
+
 defineCurve('ed25519', {
   type: 'edwards',
   prime: 'p25519',


### PR DESCRIPTION
Java's main crypto library BouncyCastle implements curve25519 in the
Weierstrass form. Adding it to elliptic allows for easier
interoperability between these two libraries.