### PR TITLE
fix(curves): Set b to 1 for curve25519

### DIFF
--- a/lib/elliptic/curves.js
+++ b/lib/elliptic/curves.js
@@ -137,7 +137,7 @@ defineCurve('curve25519', {
   prime: 'p25519',
   p: '7fffffffffffffff ffffffffffffffff ffffffffffffffff ffffffffffffffed',
   a: '76d06',
-  b: '0',
+  b: '1',
   n: '1000000000000000 0000000000000000 14def9dea2f79cd6 5812631a5cf5d3ed',
   hash: hash.sha256,
   gRed: false,


### PR DESCRIPTION
The montgomery parameters for curve25519 define b to be 1. Even though
this library doesn't use it for calculations, for consistency reasons
setting it to the standartized value improves readability. Also using it
in calculations outside of the library it resulted in problems and
errors, which will be fixed with this change.