### PR TITLE
edwards: generalise pointFromY

### DIFF
--- a/lib/elliptic/curve/edwards.js
+++ b/lib/elliptic/curve/edwards.js
@@ -91,7 +91,7 @@ EdwardsCurve.prototype.pointFromY = function pointFromY(y, odd) {
   if (x.redSqr().redSub(x2).cmp(this.zero) !== 0)
     throw new Error('invalid point');
 
-  if (x.isOdd() !== odd)
+  if (x.fromRed().isOdd() !== odd)
     x = x.redNeg();
 
   return this.point(x, y);

--- a/lib/elliptic/curve/edwards.js
+++ b/lib/elliptic/curve/edwards.js
@@ -74,10 +74,10 @@ EdwardsCurve.prototype.pointFromY = function pointFromY(y, odd) {
   if (!y.red)
     y = y.toRed(this.red);
 
-  // x^2 = (y^2 - 1) / (d y^2 + 1)
+  // x^2 = (y^2 - c^2) / (c^2 d y^2 - a)
   var y2 = y.redSqr();
-  var lhs = y2.redSub(this.one);
-  var rhs = y2.redMul(this.d).redAdd(this.one);
+  var lhs = y2.redSub(this.c2);
+  var rhs = y2.redMul(this.d).redMul(this.c2).redSub(this.a);
   var x2 = lhs.redMul(rhs.redInvm());
 
   if (x2.cmp(this.zero) === 0) {

--- a/test/curve-test.js
+++ b/test/curve-test.js
@@ -86,6 +86,30 @@ describe('Curve', function() {
     assert(point.eq(target));
   });
 
+  it('should find an odd point given a y coordinate', function() {
+    var curve = new elliptic.curve.edwards({
+      p: '7fffffffffffffff ffffffffffffffff ffffffffffffffff ffffffffffffffed',
+      a: '-1',
+      c: '1',
+      // -121665 * (121666^(-1)) (mod P)
+      d: '52036cee2b6ffe73 8cc740797779e898 00700a4d4141d8ab 75eb4dca135978a3',
+      n: '1000000000000000 0000000000000000 14def9dea2f79cd6 5812631a5cf5d3ed',
+      gRed: false,
+      g: [
+        '216936d3cd6e53fec0a4e231fdd6dc5c692cc7609525a7b2c9562d608f25d51a',
+
+        // 4/5
+        '6666666666666666666666666666666666666666666666666666666666666658'
+      ]
+    });
+
+    var bytes = new Uint8Array([5, 69, 248, 173, 171, 254, 19, 253, 143, 140, 146, 174, 26, 128, 3, 52, 106, 55, 112, 245, 62, 127, 42, 93, 0, 81, 47, 177, 30, 25, 39, 70]);
+    var y = new BN(bytes, 16, 'le');
+    var point = curve.pointFromY(y, true);
+    var target = '2cd591ae3789fd62dc420a152002f79973a387eacecadc6a9a00c1a89488c15d';
+    assert.deepStrictEqual(point.getX().toString(16), target);
+  });
+
   it('should work with secp112k1', function() {
     var curve = new elliptic.curve.short({
       p: 'db7c 2abf62e3 5e668076 bead208b',

--- a/test/curve-test.js
+++ b/test/curve-test.js
@@ -58,6 +58,34 @@ describe('Curve', function() {
     assert(p.dbl().eq(d));
   });
 
+  it('should be able to find a point given y coordinate for all edwards curves',
+    function() {
+    var curve = new elliptic.curve.edwards({
+      p: new BN('f7' +
+        'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff07',
+        16, 'le'),
+      q: new BN('71' +
+        'c966d15fd444893407d3dfc46579f7ffffffffffffffffffffffffffffff01',
+        16, 'le'),
+      r: '4',
+      a: '1',
+      // -1174 mod p
+      d: new BN('61' +
+        'fbffffffffffffffffffffffffffffffffffffffffffffffffffffffffff07',
+        16, 'le'),
+      c: '1'
+    });
+
+    var target = curve.point(
+      '05d040ddaa645bf27d2d2f302c5697231425185fd9a410f220ac5c5c7fbeb8a1',
+      '02f8ca771306cd23e929775177f2c213843a017a6487b2ec5f9b2a3808108ef2'
+    );
+
+    var point = curve.pointFromY('02' +
+      'f8ca771306cd23e929775177f2c213843a017a6487b2ec5f9b2a3808108ef2');
+    assert(point.eq(target));
+  });
+
   it('should work with secp112k1', function() {
     var curve = new elliptic.curve.short({
       p: 'db7c 2abf62e3 5e668076 bead208b',


### PR DESCRIPTION
Generalise the pointFromY method to work for all Edwards Curves by
taking `c` and `a` parameters into account.