### PR TITLE
Bug fix: recoverPubKey -> take msg as hex

### DIFF
--- a/lib/elliptic/ec/index.js
+++ b/lib/elliptic/ec/index.js
@@ -195,7 +195,7 @@ EC.prototype.recoverPubKey = function(msg, signature, j, enc) {
   signature = new Signature(signature, enc);
 
   var n = this.n;
-  var e = new BN(msg);
+  var e = new BN(msg, 16);
   var r = signature.r;
   var s = signature.s;
 


### PR DESCRIPTION
The EC.recoverPubKey(msg, signature, j, enc) should take the input `msg` as **hex** number, not **decimal**.

See https://github.com/indutny/elliptic/issues/150