### PR TITLE
fix issue: BN length different from hash result if there are leading …

### DIFF
--- a/lib/elliptic/ec/index.js
+++ b/lib/elliptic/ec/index.js
@@ -77,7 +77,16 @@ EC.prototype.genKeyPair = function genKeyPair(options) {
 };
 
 EC.prototype._truncateToN = function truncateToN(msg, truncOnly) {
-  var delta = msg.byteLength() * 8 - this.n.bitLength();
+  var bitLen
+  if (typeof msg == 'string') {
+    bitLen = msg.length * 4;
+  } else if (Object.prototype.toString.call(msg) == '[object Array]') {
+    bitLen = msg.length * 8;
+  } else if (BN.isBN(msg)) {
+    bitLen = msg.byteLength() * 8;
+  }
+  msg = new BN(msg, 16);
+  var delta = bitLen - this.n.bitLength();
   if (delta > 0)
     msg = msg.ushrn(delta);
   if (!truncOnly && msg.cmp(this.n) >= 0)
@@ -95,7 +104,7 @@ EC.prototype.sign = function sign(msg, key, enc, options) {
     options = {};
 
   key = this.keyFromPrivate(key, enc);
-  msg = this._truncateToN(new BN(msg, 16));
+  msg = this._truncateToN(msg);
 
   // Zero-extend key to provide enough entropy
   var bytes = this.n.byteLength();
@@ -118,8 +127,8 @@ EC.prototype.sign = function sign(msg, key, enc, options) {
 
   for (var iter = 0; true; iter++) {
     var k = options.k ?
-        options.k(iter) :
-        new BN(drbg.generate(this.n.byteLength()));
+      options.k(iter) :
+      new BN(drbg.generate(this.n.byteLength()));
     k = this._truncateToN(k, true);
     if (k.cmpn(1) <= 0 || k.cmp(ns1) >= 0)
       continue;
@@ -139,7 +148,7 @@ EC.prototype.sign = function sign(msg, key, enc, options) {
       continue;
 
     var recoveryParam = (kp.getY().isOdd() ? 1 : 0) |
-                        (kpX.cmp(r) !== 0 ? 2 : 0);
+      (kpX.cmp(r) !== 0 ? 2 : 0);
 
     // Use complement of `s`, if it is > `n / 2`
     if (options.canonical && s.cmp(this.nh) > 0) {
@@ -152,7 +161,7 @@ EC.prototype.sign = function sign(msg, key, enc, options) {
 };
 
 EC.prototype.verify = function verify(msg, signature, key, enc) {
-  msg = this._truncateToN(new BN(msg, 16));
+  msg = this._truncateToN(msg);
   key = this.keyFromPublic(key, enc);
   signature = new Signature(signature, 'hex');
 
@@ -190,7 +199,7 @@ EC.prototype.verify = function verify(msg, signature, key, enc) {
   return p.eqXToP(r);
 };
 
-EC.prototype.recoverPubKey = function(msg, signature, j, enc) {
+EC.prototype.recoverPubKey = function (msg, signature, j, enc) {
   assert((3 & j) === j, 'The recovery param is more than two bits');
   signature = new Signature(signature, enc);
 
@@ -220,7 +229,7 @@ EC.prototype.recoverPubKey = function(msg, signature, j, enc) {
   return this.g.mulAdd(s1, r, s2);
 };
 
-EC.prototype.getKeyRecoveryParam = function(e, signature, Q, enc) {
+EC.prototype.getKeyRecoveryParam = function (e, signature, Q, enc) {
   signature = new Signature(signature, enc);
   if (signature.recoveryParam !== null)
     return signature.recoveryParam;


### PR DESCRIPTION
Fixed bug: the sign will be invalid if the message hash has leading zeros.

The previous logic uses BN.byteLength() to calculate how many bits to shift in _truncateToN(), but it turns out if there are leading zeros in the message hash, the BN will return the length without the leading zeros. 

This will cause the signature cannot be validated in other packages.

For example, the hash hex of "1544168309783" is "001be0a5686f0c826a08601b828a2c0a347bf8cbbce0f7b6e5d87f114712395eaaf0429a5d3c224363a2602dfe91e0f6"