### PR TITLE
Update ecdsa-test.js, fix test failure

### DIFF
--- a/test/ecdsa-test.js
+++ b/test/ecdsa-test.js
@@ -61,7 +61,7 @@ describe('ECDSA', function() {
 
       it('should have `signature.s <= keys.ec.nh`', function() {
         // key.sign(msg, options)
-        var sign = keys.sign('hello', { canonical: true });
+        var sign = keys.sign(msg, { canonical: true });
         assert(sign.s.cmp(keys.ec.nh) <= 0);
       });
 


### PR DESCRIPTION
new node-bn.js 5.0.0-1 gives error when the string passed to sign function is not in hex format.

       curve secp256k1
         should have `signature.s <= keys.ec.nh`:
[0m[31m     Error: Invalid character in hello[0m[90m
      at assert (/usr/share/nodejs/bn.js/lib/bn.js:6:21)
      at parseHex (/usr/share/nodejs/bn.js/lib/bn.js:214:5)
      at BN._parseHex (/usr/share/nodejs/bn.js/lib/bn.js:241:11)
      at BN.init [as _init] (/usr/share/nodejs/bn.js/lib/bn.js:97:12)
      at new BN (/usr/share/nodejs/bn.js/lib/bn.js:39:12)
      at EC.sign (lib/elliptic/ec/index.js:99:27)
      at KeyPair.sign (lib/elliptic/ec/key.js:108:18)
      at Context.<anonymous> (test/ecdsa-test.js:64:25)
      at callFn (/usr/lib/nodejs/mocha/lib/runnable.js:354:21)
      at Test.Runnable.run (/usr/lib/nodejs/mocha/lib/runnable.js:346:7)
      at Runner.runTest (/usr/lib/nodejs/mocha/lib/runner.js:442:10)
      at /usr/lib/nodejs/mocha/lib/runner.js:560:12
      at next (/usr/lib/nodejs/mocha/lib/runner.js:356:14)
      at /usr/lib/nodejs/mocha/lib/runner.js:366:7
      at next (/usr/lib/nodejs/mocha/lib/runner.js:290:14)
      at /usr/lib/nodejs/mocha/lib/runner.js:329:7
      at done (/usr/lib/nodejs/mocha/lib/runnable.js:301:5)
      at callFn (/usr/lib/nodejs/mocha/lib/runnable.js:372:7)
      at Hook.Runnable.run (/usr/lib/nodejs/mocha/lib/runnable.js:346:7)
      at next (/usr/lib/nodejs/mocha/lib/runner.js:304:10)
      at Immediate._onImmediate (/usr/lib/nodejs/mocha/lib/runner.js:334:5)
[0m