### PR TITLE
Apply nonce bit-length mitigation to stop timing leakage.

### DIFF
--- a/lib/elliptic/ec/index.js
+++ b/lib/elliptic/ec/index.js
@@ -125,7 +125,17 @@ EC.prototype.sign = function sign(msg, key, enc, options) {
     if (k.cmpn(1) <= 0 || k.cmp(ns1) >= 0)
       continue;
 
-    var kp = this.g.mul(k);
+    // Fix the bit-length of the random nonce,
+    // so that it doesn't leak via timing.
+    // This does not change that ks = k mod n
+    var ks = k.add(this.n);
+    var kt = ks.add(this.n);
+    var kp;
+    if (ks.bitLength() == this.n.bitLength())
+      kp = this.g.mul(kt);
+    else
+      kp = this.g.mul(ks);
+
     if (kp.isInfinity())
       continue;
 

--- a/lib/elliptic/ec/index.js
+++ b/lib/elliptic/ec/index.js
@@ -131,10 +131,11 @@ EC.prototype.sign = function sign(msg, key, enc, options) {
     var ks = k.add(this.n);
     var kt = ks.add(this.n);
     var kp;
-    if (ks.bitLength() == this.n.bitLength())
+    if (ks.bitLength() === this.n.bitLength()) {
       kp = this.g.mul(kt);
-    else
+    } else {
       kp = this.g.mul(ks);
+      }
 
     if (kp.isInfinity())
       continue;


### PR DESCRIPTION
This should be a mitigation for the Minerva attack. See https://minerva.crocs.fi.muni.cz for more info. Some tests would be nice to see this is really constant time (and wasn't before), but I am not that well versed in JavaScript.