### PR TITLE
fix: Apply nonce bit-length mitigation to stop timing leakage.

### DIFF
--- a/dist/elliptic.js
+++ b/dist/elliptic.js
@@ -2288,7 +2288,18 @@ EC.prototype.sign = function sign(msg, key, enc, options) {
     if (k.cmpn(1) <= 0 || k.cmp(ns1) >= 0)
       continue;
 
-    var kp = this.g.mul(k);
+    // Fix the bit-length of the random nonce,
+    // so that it doesn't leak via timing.
+    // This does not change that ks = k mod n
+    var ks = k.add(this.n);
+    var kt = ks.add(this.n);
+    var kp;
+    if (ks.bitLength() === this.n.bitLength()) {
+      kp = this.g.mul(kt);
+    } else {
+      kp = this.g.mul(ks);
+    }
+
     if (kp.isInfinity())
       continue;
 

--- a/lib/elliptic/ec/index.js
+++ b/lib/elliptic/ec/index.js
@@ -125,7 +125,17 @@ EC.prototype.sign = function sign(msg, key, enc, options) {
     if (k.cmpn(1) <= 0 || k.cmp(ns1) >= 0)
       continue;
 
-    var kp = this.g.mul(k);
+    // Fix the bit-length of the random nonce,
+    // so that it doesn't leak via timing.
+    // This does not change that ks = k mod n
+    var ks = k.add(this.n);
+    var kt = ks.add(this.n);
+    var kp;
+    if (ks.bitLength() == this.n.bitLength())
+      kp = this.g.mul(kt);
+    else
+      kp = this.g.mul(ks);
+
     if (kp.isInfinity())
       continue;
 

--- a/lib/elliptic/ec/index.js
+++ b/lib/elliptic/ec/index.js
@@ -135,7 +135,7 @@ EC.prototype.sign = function sign(msg, key, enc, options) {
       kp = this.g.mul(kt);
     } else {
       kp = this.g.mul(ks);
-      }
+    }
 
     if (kp.isInfinity())
       continue;

--- a/lib/elliptic/ec/index.js
+++ b/lib/elliptic/ec/index.js
@@ -131,10 +131,11 @@ EC.prototype.sign = function sign(msg, key, enc, options) {
     var ks = k.add(this.n);
     var kt = ks.add(this.n);
     var kp;
-    if (ks.bitLength() == this.n.bitLength())
+    if (ks.bitLength() === this.n.bitLength()) {
       kp = this.g.mul(kt);
-    else
+    } else {
       kp = this.g.mul(ks);
+      }
 
     if (kp.isInfinity())
       continue;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elliptic",
-  "version": "6.5.1",
+  "version": "6.5.2",
   "description": "EC cryptography",
   "main": "lib/elliptic.js",
   "files": [


### PR DESCRIPTION
This is a follow-up PR to https://github.com/indutny/elliptic/pull/203, created by @J08nY that adds the following:
- [x] code style error, as seen on [travis build](https://travis-ci.org/indutny/elliptic/jobs/600683572)
- [x] add built change to `/dist`
- [x] bumps version to `6.5.2`

I could've first PR'd to @J08nY's fork and then have it here, but wanted to take the shortcut, for simplicity sake.

Travis job for sauce labs testing will probably fail due to the lack of an API key for builds in external forks. It's listed as an optional test, so might not be that important.