### PR TITLE
bump bn.js to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mocha": "^6.2.2"
   },
   "dependencies": {
-    "bn.js": "^4.4.0",
+    "bn.js": "^5.0.0",
     "brorand": "^1.0.1",
     "hash.js": "^1.0.0",
     "hmac-drbg": "^1.0.0",

--- a/test/ecdsa-test.js
+++ b/test/ecdsa-test.js
@@ -61,7 +61,7 @@ describe('ECDSA', function() {
 
       it('should have `signature.s <= keys.ec.nh`', function() {
         // key.sign(msg, options)
-        var sign = keys.sign('hello', { canonical: true });
+        var sign = keys.sign(Buffer.from('hello'), { canonical: true });
         assert(sign.s.cmp(keys.ec.nh) <= 0);
       });
 


### PR DESCRIPTION
https://github.com/indutny/elliptic/issues/191 (`elliptic` need bump to 6.6.0)
Also need `remove package-lock.json` OR `update package-lock.json`.

Depends from:
https://github.com/indutny/asn1.js/pull/118
https://github.com/crypto-browserify/browserify-rsa/pull/13
https://github.com/crypto-browserify/browserify-sign/pull/47
https://github.com/crypto-browserify/createECDH/pull/15
https://github.com/crypto-browserify/diffie-hellman/pull/32
https://github.com/indutny/miller-rabin/pull/11
https://github.com/crypto-browserify/publicEncrypt/pull/20