### PR TITLE
getKeyRecoveryParam method reusing variable `e`, type incorrect

### DIFF
--- a/lib/elliptic/ec/index.js
+++ b/lib/elliptic/ec/index.js
@@ -223,7 +223,7 @@ EC.prototype.recoverPubKey = function(msg, signature, j, enc) {
   return this.g.mulAdd(s1, r, s2);
 };
 
-EC.prototype.getKeyRecoveryParam = function(e, signature, Q, enc) {
+EC.prototype.getKeyRecoveryParam = function(msg, signature, Q, enc) {
   signature = new Signature(signature, enc);
   if (signature.recoveryParam !== null)
     return signature.recoveryParam;
@@ -231,7 +231,7 @@ EC.prototype.getKeyRecoveryParam = function(e, signature, Q, enc) {
   for (var i = 0; i < 4; i++) {
     var Qprime;
     try {
-      Qprime = this.recoverPubKey(e, signature, i);
+      Qprime = this.recoverPubKey(msg, signature, i);
     } catch (e) {
       continue;
     }


### PR DESCRIPTION
`@types/elliptic` states that `getKeyRecoveryParam` `e` variable is `Error | undefined`: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a9f3af6e4416678bad8027c15627683621f532f1/types/elliptic/index.d.ts#L219

However, other than within the scope of the `catch (e) {...}` where it is `Error | undefined`, the type is more likely either `BNInput` or one of the types `BNInput` represents as it is passed into `recoverPubKey`: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a9f3af6e4416678bad8027c15627683621f532f1/types/elliptic/index.d.ts#L213

Likely why the `@types/elliptic` has the type wrong is due to `e` being redeclared in the `catch` statement.  This PR is just to fix the redeclaration.