### PR TITLE
fix: decode ec point according to the spec

### DIFF
--- a/lib/elliptic/curve/edwards.js
+++ b/lib/elliptic/curve/edwards.js
@@ -49,6 +49,8 @@ EdwardsCurve.prototype.jpoint = function jpoint(x, y, z, t) {
 
 EdwardsCurve.prototype.pointFromX = function pointFromX(x, odd) {
   x = new BN(x, 16);
+  if (x.cmp(this.p) >= 0)
+    throw new Error('invalid point');
   if (!x.red)
     x = x.toRed(this.red);
 
@@ -70,6 +72,8 @@ EdwardsCurve.prototype.pointFromX = function pointFromX(x, odd) {
 
 EdwardsCurve.prototype.pointFromY = function pointFromY(y, odd) {
   y = new BN(y, 16);
+  if (y.cmp(this.p) >= 0)
+    throw new Error('invalid point');
   if (!y.red)
     y = y.toRed(this.red);
 

--- a/test/ed25519-test.js
+++ b/test/ed25519-test.js
@@ -111,6 +111,24 @@ describe('EDDSA(\'ed25519\')', function() {
     assert(key.verify(msg, sig));
   });
 
+  it('should throw when trying to decode invalid bytes (1)', function() {
+    assert.throws(function() {
+      ed25519.decodePoint('c2cb3cf3840aa9893e00ec77093d3d44dba7da840b51c48462072d58d8efd183');
+    });
+  });
+
+  it('should throw when trying to decode invalid bytes (2)', function() {
+    assert.throws(function() {
+      ed25519.decodePoint('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff');
+    });
+  });
+
+  it('should throw when trying to decode invalid bytes (3)', function() {
+    assert.throws(function() {
+      ed25519.decodePoint('edffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f');
+    });
+  });
+
   describe('KeyPair', function() {
     var pair;
     var secret = '00000000000000000000000000000000' +


### PR DESCRIPTION
This PR includes `decodePoint` method according to the specification: https://tools.ietf.org/html/rfc8032#section-5.1.3

> If the resulting value is >= p, decoding fails.

There are some tests, if needed more tests can be added.

Related issue: https://github.com/indutny/elliptic/issues/250