### PR TITLE
adding bracket around assert

### DIFF
--- a/lib/elliptic/curve/base.js
+++ b/lib/elliptic/curve/base.js
@@ -275,10 +275,11 @@ BaseCurve.prototype.decodePoint = function decodePoint(bytes, enc) {
   // uncompressed, hybrid-odd, hybrid-even
   if ((bytes[0] === 0x04 || bytes[0] === 0x06 || bytes[0] === 0x07) &&
       bytes.length - 1 === 2 * len) {
-    if (bytes[0] === 0x06)
+    if (bytes[0] === 0x06) {
       assert(bytes[bytes.length - 1] % 2 === 0);
-    else if (bytes[0] === 0x07)
+    } else if (bytes[0] === 0x07) {
       assert(bytes[bytes.length - 1] % 2 === 1);
+    }
 
     var res =  this.point(bytes.slice(1, 1 + len),
       bytes.slice(1 + len, 1 + 2 * len));


### PR DESCRIPTION
for some reason unknown to me, the `assert` are being removed by our webpack build which is causing a build error of our all app. Simply adding brackets around those `if/else if` is solving the problem.